### PR TITLE
Fixed pouchdb JSON.parse

### DIFF
--- a/packages/express-pouchdb/lib/routes/changes.js
+++ b/packages/express-pouchdb/lib/routes/changes.js
@@ -72,10 +72,11 @@ module.exports = function (app) {
             cleanup();
           } else { // do the longpolling
             // mimicking CouchDB, start sending the JSON immediately
-            res.write('{"results":[\n');
+            // res.write('{"results":[\n');
             req.query.live = req.query.continuous = true;
             changes = req.db.changes(req.query)
               .on('change', function (change) {
+                res.write('{"results":[\n');
                 utils.writeJSON(res, change);
                 res.write('],\n"last_seq":' + change.seq + '}\n');
                 cleanup();


### PR DESCRIPTION
We've found a way for our `pouchdb` to receive `{"results":[\n` with 200 status. This is possible because `cleanup` will do `res.end` in our version of `express-pouchdb`. This is fixed in the latest version of `express-pouchdb`. We can fix this just by commenting `mimicking CouchDB` code, we don't need this.